### PR TITLE
Add CODE_OF_CONDUCT file to the Project

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,60 @@
+# The Library Project Code of Conduct
+
+## Welcome
+
+Welcome to **The Library** repository! This project is an unofficial guide providing a variety of infosec learning paths. We are committed to maintaining a positive, inclusive, and harassment-free environment for everyone involved.
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our project and community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+- Demonstrating empathy and kindness toward others
+- Being respectful of differing opinions, viewpoints, and experiences
+- Gracefully accepting constructive feedback
+- Apologizing when mistakes are made, and learning from the experience
+- Focusing on what is best for the community
+
+Unacceptable behavior includes:
+
+- The use of sexualized language or imagery and unwelcome sexual attention
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Harassment in any form, including public or private harassment
+- Publishing others’ private information without explicit permission
+- Any other conduct which would reasonably be considered inappropriate in a professional setting
+
+## Project Specifics
+
+**The Library** repository serves as an unofficial guide to various infosec learning paths. It is a community-driven project where contributors can share resources and guidance for those interested in learning more about information security.
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing standards of acceptable behavior and will take appropriate corrective action in response to any unacceptable behavior.
+
+Leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned with this Code of Conduct. They may also take action to address anything they deem inappropriate.
+
+## Scope
+
+This Code of Conduct applies to all spaces managed by **The Library**, including GitHub repositories, communication channels, and public spaces where individuals represent the community.
+
+## Reporting Violations
+
+Instances of abusive, harassing, or unacceptable behavior can be reported through appropriate channels within the community. Even though there is no direct POC or email available, community leaders will make efforts to address violations promptly and fairly.
+
+## Enforcement Guidelines
+
+Community leaders will follow these guidelines to determine the consequences for violations of this Code of Conduct:
+
+1. **Correction**: A private warning about the violation with clarity on why the behavior was inappropriate.
+2. **Warning**: A warning and temporary restrictions from interacting with the community.
+3. **Temporary Ban**: A temporary ban for serious violations.
+4. **Permanent Ban**: A permanent ban for repeated or severe violations.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.0, available [here](https://www.contributor-covenant.org/version/2/0/code_of_conduct.html


### PR DESCRIPTION
closes #7 

This PR is related to adding a new code of conduct markdown file for the viewers and contributors of the Project : The_Library. Please review and share the feedback as necessary. Thank you.